### PR TITLE
Release v0.0.5

### DIFF
--- a/sql_runner/clickhouse_runner.py
+++ b/sql_runner/clickhouse_runner.py
@@ -1,4 +1,5 @@
 import clickhouse_connect
+from typing import Any
 
 from sql_runner.core import ConnectionConfig, SQLRunner
 
@@ -7,7 +8,7 @@ class ClickHouseRunner(SQLRunner):
     def __init__(
             self,
             connection_config: ConnectionConfig,
-            secure: bool = True
+            **kwargs: Any
     ):
         super().__init__(connection_config=connection_config)
 
@@ -17,7 +18,8 @@ class ClickHouseRunner(SQLRunner):
             user=connection_config.user,
             password=connection_config.password,
             database=connection_config.database,
-            secure=secure
+            secure=kwargs.get("secure", True),
+            **kwargs
         )
 
     def __enter__(self):

--- a/sql_runner/trino_runner.py
+++ b/sql_runner/trino_runner.py
@@ -11,8 +11,7 @@ class TrinoRunner(SQLRunner):
     def __init__(
             self,
             connection_config: ConnectionConfig,
-            isolation_level: IsolationLevel = IsolationLevel.AUTOCOMMIT,
-            client_tags: list[str] = None,
+            **kwargs
     ):
         super().__init__(connection_config=connection_config)
 
@@ -20,7 +19,7 @@ class TrinoRunner(SQLRunner):
         auth = (
             trino.auth.BasicAuthentication(self.connection_config.user, self.connection_config.password)
             if self.connection_config.password
-            else None
+            else trino.constants.DEFAULT_AUTH
         )
 
         self.conn = trino.dbapi.connect(
@@ -31,8 +30,7 @@ class TrinoRunner(SQLRunner):
             schema=self.connection_config.schema,
             http_scheme=http_scheme,
             auth=auth,
-            isolation_level=isolation_level,
-            client_tags=client_tags,
+            **kwargs,
         )
 
     def __enter__(self):

--- a/sql_runner/utils.py
+++ b/sql_runner/utils.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import boto3
 from botocore.exceptions import ClientError
 from dataclasses import dataclass
@@ -125,7 +127,7 @@ def create_postgres_runner_from_aws_secret(
 def create_trino_runner_from_env(
         env_path: Path | str,
         env_mapping: EnvMapping | dict = None,
-        client_tags: list[str] = None,
+        **kwargs: Any,
 ):
     connection_config = create_connection_config_from_env(
         env_path=env_path,
@@ -134,7 +136,7 @@ def create_trino_runner_from_env(
 
     return TrinoRunner(
         connection_config=connection_config,
-        client_tags=client_tags,
+        **kwargs,
     )
 
 
@@ -142,11 +144,8 @@ def create_trino_runner_from_aws_secret(
         secret_name: str,
         region: str = "us-east-1",
         session: boto3.session.Session | None = None,
-        client_tags: list[str] = None,
+        **kwargs
 ):
-    if client_tags is None:
-        client_tags = []
-
     connection_config = create_connection_config_from_secret(
         secret_name=secret_name,
         region=region,
@@ -155,5 +154,5 @@ def create_trino_runner_from_aws_secret(
 
     return TrinoRunner(
         connection_config=connection_config,
-        client_tags=client_tags,
+        **kwargs
     )


### PR DESCRIPTION
### Description

- Updates the `TrinoRunner` and `ClickHouseRunner` to accept `**kwargs`, which can be passed to the underlying connection logic